### PR TITLE
Disable unaligned load and store in miniz per default

### DIFF
--- a/src/miniz/miniz.h
+++ b/src/miniz/miniz.h
@@ -174,7 +174,8 @@
 #if !defined(MINIZ_USE_UNALIGNED_LOADS_AND_STORES)
 #if MINIZ_X86_OR_X64_CPU
 /* Set MINIZ_USE_UNALIGNED_LOADS_AND_STORES to 1 on CPU's that permit efficient integer loads and stores from unaligned addresses. */
-#define MINIZ_USE_UNALIGNED_LOADS_AND_STORES 1
+/* TODO: Only disable for debug build */
+#define MINIZ_USE_UNALIGNED_LOADS_AND_STORES 0
 #define MINIZ_UNALIGNED_USE_MEMCPY
 #else
 #define MINIZ_USE_UNALIGNED_LOADS_AND_STORES 0


### PR DESCRIPTION
I ran into the same issue as https://github.com/richgel999/miniz/issues/72

When I run a debug build with `gdb`, I get the following error message:

```CPP
src/miniz/miniz.cpp:3484:21: runtime error: load of misaligned address 0x7fffffff6b29 for type 'const mz_uint32', which requires 4 byte alignment
0x7fffffff6b29: note: pointer points here
 00 00 68  0a 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  cb 50 6c f7 ff 7f 00 00  50 6b ff ff ff
              ^ 
[1] + Done                       "/usr/bin/gdb"
```

This PR would disable `MINIZ_USE_UNALIGNED_LOADS_AND_STORES` entirely. But this is also not quite what I want, since enabling the option for a production build is fine & also desired (since it's probably faster -- I would have to benchmark the difference though).

Maybe you could create another “debug” branch, where the option is disabled.

(Some context: I ran into this issue when running the debug build of https://github.com/polydbms/sheetreader-duckdb --- I would add a note, that users should switch to the other branch of `sheetreader-core`, when compiling the debug build)